### PR TITLE
Updated error handling to use Error class

### DIFF
--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -21,7 +21,7 @@
 					arg = argv[cursor];
 					for (k = 0; k < match[2].length; k++) {
 						if (!arg.hasOwnProperty(match[2][k])) {
-							throw(sprintf('[sprintf] property "%s" does not exist', match[2][k]));
+							throw new Error(sprintf('[sprintf] property "%s" does not exist', match[2][k]));
 						}
 						arg = arg[match[2][k]];
 					}
@@ -34,7 +34,7 @@
 				}
 
 				if (/[^s]/.test(match[8]) && (get_type(arg) != 'number')) {
-					throw(sprintf('[sprintf] expecting number but found %s', get_type(arg)));
+					throw new Error(sprintf('[sprintf] expecting number but found %s', get_type(arg)));
 				}
 				switch (match[8]) {
 					case 'b': arg = arg.toString(2); break;
@@ -83,12 +83,12 @@
 								field_list.push(field_match[1]);
 							}
 							else {
-								throw('[sprintf] huh?');
+								throw new Error('[sprintf] huh?');
 							}
 						}
 					}
 					else {
-						throw('[sprintf] huh?');
+						throw new Error('[sprintf] huh?');
 					}
 					match[2] = field_list;
 				}
@@ -96,12 +96,12 @@
 					arg_names |= 2;
 				}
 				if (arg_names === 3) {
-					throw('[sprintf] mixing positional and named placeholders is not (yet) supported');
+					throw new Error('[sprintf] mixing positional and named placeholders is not (yet) supported');
 				}
 				parse_tree.push(match);
 			}
 			else {
-				throw('[sprintf] huh?');
+				throw new Error('[sprintf] huh?');
 			}
 			_fmt = _fmt.substring(match[0].length);
 		}


### PR DESCRIPTION
Minor change - I'm using sprintf.js in a system with JavaScript promises, and throwing Errors so the stack trace is visible (see also: http://stackoverflow.com/q/9183159/40352)

sprintf.js is great, thanks for making it!
