### PR TITLE
Add bower.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,19 @@ Keywords in replacement fields can be optionally followed by any number of keywo
 	sprintf('Hello %(users[0].name)s, %(users[1].name)s and %(users[2].name)s', {users: users}); // Hello Dolly, Molly and Polly
 Note: mixing positional and named placeholders is not (yet) supported
 
-# As a node.js module
-## Install
+# Installation
+
+## via Bower
+
+	bower install sprintf
+
+## as a node.js module
+
+### Install
 
 	npm install sprintf-js
 
-## How to
+### Usage
 
 	var sprintf = require("sprintf-js").sprintf,
 		vsprintf = require("sprintf-js").vsprintf;

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,14 @@
+{
+  "name": "sprintf",
+  "description": "JavaScript sprintf implementation",
+  "version": "0.0.7",
+  "main": "src/sprintf.js",
+  "license": "BSD-3-Clause-Clear",
+  "keywords": ["sprintf", "string", "formatting"],
+  "authors": ["Alexandru Marasteanu <hello@alexei.ro> (http://alexei.ro/)"],
+  "homepage": "https://github.com/alexei/sprintf.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/alexei/sprintf.js.git"
+  }
+}


### PR DESCRIPTION
Adds Bower support. Uses name "sprintf" as this is what's already registered in Bower: http://bower.io/search/?q=sprintf
