### PR TITLE
Use 'i' as an alias for a decimal specifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The placeholders in the format string are marked by "%" and are followed by one 
     * % — print a literal "%" character
     * b — print an integer as a binary number
     * c — print an integer as the character with that ASCII value
-    * d — print an integer as a signed decimal number
+    * d or i — print an integer as a signed decimal number
     * e — print a float as scientific notation
     * u — print an integer as an unsigned decimal number
     * f — print a float as is

--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -1,10 +1,10 @@
 (function(window) {
     var re = {
         not_string: /[^s]/,
-        number: /[def]/,
+        number: /[dief]/,
         text: /^[^\x25]+/,
         modulo: /^\x25{2}/,
-        placeholder: /^\x25(?:([1-9]\d*)\$|\(([^\)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-fosuxX])/,
+        placeholder: /^\x25(?:([1-9]\d*)\$|\(([^\)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-fiosuxX])/,
         key: /^([a-z_][a-z_\d]*)/i,
         key_access: /^\.([a-z_][a-z_\d]*)/i,
         index_access: /^\[(\d+)\]/,
@@ -64,6 +64,7 @@
                         arg = String.fromCharCode(arg)
                     break
                     case "d":
+                    case "i":
                         arg = parseInt(arg, 10)
                     break
                     case "e":

--- a/test/test.js
+++ b/test/test.js
@@ -9,7 +9,9 @@ describe("sprintfjs", function() {
         assert.equal("10", sprintf("%b", 2))
         assert.equal("A", sprintf("%c", 65))
         assert.equal("2", sprintf("%d", 2))
+        assert.equal("2", sprintf("%i", 2))
         assert.equal("2", sprintf("%d", "2"))
+        assert.equal("2", sprintf("%i", "2"))
         assert.equal("2e+0", sprintf("%e", 2))
         assert.equal("2", sprintf("%u", 2))
         assert.equal("4294967294", sprintf("%u", -2))
@@ -28,6 +30,10 @@ describe("sprintfjs", function() {
         assert.equal("-2", sprintf("%d", -2))
         assert.equal("+2", sprintf("%+d", 2))
         assert.equal("-2", sprintf("%+d", -2))
+        assert.equal("2", sprintf("%i", 2))
+        assert.equal("-2", sprintf("%i", -2))
+        assert.equal("+2", sprintf("%+i", 2))
+        assert.equal("-2", sprintf("%+i", -2))
         assert.equal("2.2", sprintf("%f", 2.2))
         assert.equal("-2.2", sprintf("%f", -2.2))
         assert.equal("+2.2", sprintf("%+f", 2.2))
@@ -39,6 +45,7 @@ describe("sprintfjs", function() {
 
         // padding
         assert.equal("-0002", sprintf("%05d", -2))
+        assert.equal("-0002", sprintf("%05i", -2))
         assert.equal("    <", sprintf("%5s", "<"))
         assert.equal("0000<", sprintf("%05s", "<"))
         assert.equal("____<", sprintf("%'_5s", "<"))


### PR DESCRIPTION
Was unable to use sprintf.js as a drop-in replacement, the specifier `i` was not recognized.

It's an old convention, `%i` is seen in both [C sprintf](http://www.tutorialspoint.com/c_standard_library/c_function_sprintf.htm) and [C++ printf](http://www.cplusplus.com/reference/cstdio/printf/).
