### PR TITLE
bumped sprintf version in bower.json from 0.0.7 to 1.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "sprintf",
   "description": "JavaScript sprintf implementation",
-  "version": "0.0.7",
+  "version": "1.0.0",
   "main": "src/sprintf.js",
   "license": "BSD-3-Clause-Clear",
   "keywords": ["sprintf", "string", "formatting"],


### PR DESCRIPTION
Requesting version 1.0.0 in bower.json and then performing a bower install results in the following:

> bower sprintf#1.0.0                   mismatch Version declared in the json (0.0.7) is different than the resolved one (1.0.0)
> bower sprintf#1.0.0                   resolved git://github.com/alexei/sprintf.js.git#1.0.0

This just bumps the version in bower.json to match the git tag and package.json. I'm not sure if it would be simpler to make similar but slightly different changes and then add a new tag of 1.0.1 (since the 1.0.0 tag would have to move otherwise).
