### PR TITLE
Update version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "sprintf",
   "description": "JavaScript sprintf implementation",
-  "version": "0.0.7",
+  "version": "1.0.0",
   "main": "src/sprintf.js",
   "license": "BSD-3-Clause-Clear",
   "keywords": ["sprintf", "string", "formatting"],


### PR DESCRIPTION
For bower to work properly, there should be a tag with the same name as the version, "1.0.0".
