### PR TITLE
Fix Syntax error in Asset Manager

### DIFF
--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -188,4 +188,4 @@
             })
         }
     }
-})(typeof window === "undefined" ? this : window)
+})(typeof window === "undefined" ? this : window);


### PR DESCRIPTION
```
Uncaught TypeError: undefined is not a function
```
