### PR TITLE
Adds empty ignore entry to bower.json. Fixes #71

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,5 +10,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/alexei/sprintf.js.git"
-  }
+  },
+  "ignore": []
 }


### PR DESCRIPTION
Missing ignore entry causes a warning from bower when installing as a dependency.

`bower invalid-meta sprintf is missing "ignore" entry in bower.json`

Added empty ignore entry as a workaround as discussed here: https://github.com/bower/bower/issues/1388
