### PR TITLE
empty string instead of 'undefined' for missing params. Fixes #49

### DIFF
--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -57,6 +57,10 @@
                 if (re.number.test(match[8])) {
                     is_positive = arg >= 0
                 }
+                
+                if (typeof arg === "undefined") {
+                    arg = ""
+                }
 
                 switch (match[8]) {
                     case "b":


### PR DESCRIPTION
This a quick fix for https://github.com/alexei/sprintf.js/issues/49
I decided to use empty string instead of throwing errors. 