### PR TITLE
Adding support for alfanumeric index access

### DIFF
--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -17,7 +17,7 @@
         placeholder: /^\x25(?:([1-9]\d*)\$|\(([^\)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-gijostTuvxX])/,
         key: /^([a-z_][a-z_\d]*)/i,
         key_access: /^\.([a-z_][a-z_\d]*)/i,
-        index_access: /^\[(\d+)\]/,
+        index_access: /^\[([A-Z0-9a-z]+)\]/,
         sign: /^[\+\-]/
     }
 


### PR DESCRIPTION
You can have alfanumeric keys together with numeric keys. I changed the regular expression to fix this. 

Example: 
```
var arrResults = {"ID4":{"MAXNUMBERPRATICA":"27652","_odbc_connection_id":"ID4"},"4":{"MAXNUMBERPRATICA":"123456","_odbc_connection_id":"ID4"}};
console.log(sprintf("check results = %(arrResults[4].MAXNUMBERPRATICA)s",{"arrResults":arrResults}));
console.log(sprintf("check results = %(arrResults[ID4].MAXNUMBERPRATICA)s",{"arrResults":arrResults}));
```