### PR TITLE
allow for browser and node assignments for certain cases involving es…

### DIFF
--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -229,7 +229,7 @@
         exports.sprintf = sprintf
         exports.vsprintf = vsprintf
     }
-    else {
+    if (typeof window !== 'undefined') {
         window.sprintf = sprintf
         window.vsprintf = vsprintf
 


### PR DESCRIPTION
…6, webpack, typescript
I ran into a problem when I upgraded to Typescript 2 and used WebPack to bundle my commonJS into browser code.  It appears the 'exports' is detected, but I really need vsprintf to become availabable globally in the browser.  This change allows for either or both.