### PR TITLE
allow to use named placeholder w/o type specifier

### DIFF
--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -14,7 +14,7 @@
         not_json: /[^j]/,
         text: /^[^\x25]+/,
         modulo: /^\x25{2}/,
-        placeholder: /^\x25(?:([1-9]\d*)\$|\(([^\)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-gijostTuvxX])/,
+        placeholder: /^\x25(?:([1-9]\d*)\$|\(([^\)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-gijostTuvxX])?/,
         key: /^([a-z_][a-z_\d]*)/i,
         key_access: /^\.([a-z_][a-z_\d]*)/i,
         index_access: /^\[(\d+)\]/,
@@ -150,7 +150,7 @@
             else if ((match = re.modulo.exec(_fmt)) !== null) {
                 parse_tree[parse_tree.length] = '%'
             }
-            else if ((match = re.placeholder.exec(_fmt)) !== null) {
+            else if ((match = re.placeholder.exec(_fmt)) !== null && match[0] !== '%') {
                 if (match[2]) {
                     arg_names |= 1
                     var field_list = [], replacement_field = match[2], field_match = []
@@ -178,6 +178,9 @@
                 }
                 if (arg_names === 3) {
                     throw new Error("[sprintf] mixing positional and named placeholders is not (yet) supported")
+                }
+                if (typeof match[8] === 'undefined') {
+                    match[8] = 's';
                 }
                 parse_tree[parse_tree.length] = match
             }

--- a/test/test.js
+++ b/test/test.js
@@ -28,7 +28,6 @@ describe("sprintfjs", function() {
         assert.equal("ff", sprintf("%x", 255))
         assert.equal("FF", sprintf("%X", 255))
         assert.equal("Polly wants a cracker", sprintf("%2$s %3$s a %1$s", "cracker", "Polly", "wants"))
-        assert.equal("Hello world!", sprintf("Hello %(who)s!", {"who": "world"}))
         assert.equal("true", sprintf("%t", true))
         assert.equal("t", sprintf("%.1t", true))
         assert.equal("true", sprintf("%t", "true"))
@@ -54,6 +53,13 @@ describe("sprintfjs", function() {
         assert.equal('1,2,3', sprintf('%v', [1, 2, 3]))
         assert.equal('[object Object]', sprintf('%v', {foo: 'bar'}))
         assert.equal('/<("[^"]*"|\'[^\']*\'|[^\'">])*>/', sprintf('%v', /<("[^"]*"|'[^']*'|[^'">])*>/))
+    })
+
+    it("should return formated strings for named placeholders", function() {
+        assert.equal("Hello world!", sprintf("Hello %(who)s!", {"who": "world"}))
+        assert.equal("Hello world !", sprintf("Hello %(who) !", {"who": "world"}))
+        assert.equal("Hello world!", sprintf("Hello %(who)!", {"who": "world"}))
+        assert.equal("Hello world !", sprintf("Hello %(who)s !", {"who": "world"}))
     })
 
     it("should return formated strings for complex placeholders", function() {


### PR DESCRIPTION
If not specified the `s` will be used by default `%(txt) === %(txt)s`.