### PR TITLE
Add support for %S 

### DIFF
--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -14,7 +14,7 @@
         not_json: /[^j]/,
         text: /^[^\x25]+/,
         modulo: /^\x25{2}/,
-        placeholder: /^\x25(?:([1-9]\d*)\$|\(([^\)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-gijostTuvxX])/,
+        placeholder: /^\x25(?:([1-9]\d*)\$|\(([^\)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-gijosStTuvxX])/,
         key: /^([a-z_][a-z_\d]*)/i,
         key_access: /^\.([a-z_][a-z_\d]*)/i,
         index_access: /^\[(\d+)\]/,
@@ -93,6 +93,7 @@
                         arg = arg.toString(8)
                     break
                     case 's':
+                    case 'S':
                         arg = String(arg)
                         arg = (match[7] ? arg.substring(0, match[7]) : arg)
                     break

--- a/test/test.js
+++ b/test/test.js
@@ -25,6 +25,7 @@ describe("sprintfjs", function() {
         assert.equal("3.141592653589793", sprintf("%g", pi))
         assert.equal("10", sprintf("%o", 8))
         assert.equal("%s", sprintf("%s", "%s"))
+        assert.equal("%S", sprintf("%S", "%S"))
         assert.equal("ff", sprintf("%x", 255))
         assert.equal("FF", sprintf("%X", 255))
         assert.equal("Polly wants a cracker", sprintf("%2$s %3$s a %1$s", "cracker", "Polly", "wants"))
@@ -92,6 +93,7 @@ describe("sprintfjs", function() {
         assert.equal("1234", sprintf("%02u", 1234))
         assert.equal(" -10.235", sprintf("%8.3f", -10.23456))
         assert.equal("-12.34 xxx", sprintf("%f %s", -12.34, "xxx"))
+        assert.equal("-12.34 xxx", sprintf("%f %S", -12.34, "xxx"))
         assert.equal('{\n  "foo": "bar"\n}', sprintf("%2j", {foo: "bar"}))
         assert.equal('[\n  "foo",\n  "bar"\n]', sprintf("%2j", ["foo", "bar"]))
 


### PR DESCRIPTION
Other language sprintf implementations accept `%S` as a pseudonym for `%s`

http://searchfox.org/mozilla-central/search?q=%25S&case=true&path=