### PR TITLE
Optimizations for modern browsers

### DIFF
--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -30,10 +30,10 @@
     }
 
     sprintf.format = function(parse_tree, argv) {
-        var cursor = 1, tree_length = parse_tree.length, arg, output = [], i, k, match, pad, pad_character, pad_length, is_positive, sign
+        var cursor = 1, tree_length = parse_tree.length, arg, output = '', i, k, match, pad, pad_character, pad_length, is_positive, sign
         for (i = 0; i < tree_length; i++) {
             if (typeof parse_tree[i] === 'string') {
-                output[output.length] = parse_tree[i]
+                output += parse_tree[i]
             }
             else if (parse_tree[i] instanceof Array) {
                 match = parse_tree[i] // convenience purposes only
@@ -118,7 +118,7 @@
                     break
                 }
                 if (re.json.test(match[8])) {
-                    output[output.length] = arg
+                    output += arg
                 }
                 else {
                     if (re.number.test(match[8]) && (!is_positive || match[3])) {
@@ -131,11 +131,11 @@
                     pad_character = match[4] ? match[4] === '0' ? '0' : match[4].charAt(1) : ' '
                     pad_length = match[6] - (sign + arg).length
                     pad = match[6] ? (pad_length > 0 ? pad_character.repeat(pad_length) : '') : ''
-                    output[output.length] = match[5] ? sign + arg + pad : (pad_character === '0' ? sign + pad + arg : pad + sign + arg)
+                    output += match[5] ? sign + arg + pad : (pad_character === '0' ? sign + pad + arg : pad + sign + arg)
                 }
             }
         }
-        return output.join('')
+        return output
     }
 
     sprintf.cache = Object.create(null)

--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -131,7 +131,7 @@
                     }
                     pad_character = match[4] ? match[4] === '0' ? '0' : match[4].charAt(1) : ' '
                     pad_length = match[6] - (sign + arg).length
-                    pad = match[6] ? (pad_length > 0 ? str_repeat(pad_character, pad_length) : '') : ''
+                    pad = match[6] ? (pad_length > 0 ? pad_character.repeat(pad_length) : '') : ''
                     output[output.length] = match[5] ? sign + arg + pad : (pad_character === '0' ? sign + pad + arg : pad + sign + arg)
                 }
             }
@@ -208,18 +208,6 @@
         else {
             return Object.prototype.toString.call(variable).slice(8, -1).toLowerCase()
         }
-    }
-
-    var preformattedPadding = {
-        '0': ['', '0', '00', '000', '0000', '00000', '000000', '0000000'],
-        ' ': ['', ' ', '  ', '   ', '    ', '     ', '      ', '       '],
-        '_': ['', '_', '__', '___', '____', '_____', '______', '_______'],
-    }
-    function str_repeat(input, multiplier) {
-        if (multiplier >= 0 && multiplier <= 7 && preformattedPadding[input]) {
-            return preformattedPadding[input][multiplier]
-        }
-        return Array(multiplier + 1).join(input)
     }
 
     /**

--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -21,8 +21,8 @@
         sign: /^[\+\-]/
     }
 
-    function sprintf() {
-        var key = arguments[0], cache = sprintf.cache
+    function sprintf(key) {
+        var cache = sprintf.cache
         if (!(cache[key])) {
             cache[key] = sprintf.parse(key)
         }

--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -30,7 +30,7 @@
     }
 
     sprintf.format = function(parse_tree, argv) {
-        var cursor = 1, tree_length = parse_tree.length, arg, output = [], i, k, match, pad, pad_character, pad_length, is_positive = true, sign = ''
+        var cursor = 1, tree_length = parse_tree.length, arg, output = [], i, k, match, pad, pad_character, pad_length, is_positive, sign
         for (i = 0; i < tree_length; i++) {
             if (typeof parse_tree[i] === 'string') {
                 output[output.length] = parse_tree[i]
@@ -141,7 +141,7 @@
     sprintf.cache = Object.create(null)
 
     sprintf.parse = function(fmt) {
-        var _fmt = fmt, match = [], parse_tree = [], arg_names = 0
+        var _fmt = fmt, match, parse_tree = [], arg_names = 0
         while (_fmt) {
             if ((match = re.text.exec(_fmt)) !== null) {
                 parse_tree[parse_tree.length] = match[0]

--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -30,13 +30,12 @@
     }
 
     sprintf.format = function(parse_tree, argv) {
-        var cursor = 1, tree_length = parse_tree.length, node_type = '', arg, output = [], i, k, match, pad, pad_character, pad_length, is_positive = true, sign = ''
+        var cursor = 1, tree_length = parse_tree.length, arg, output = [], i, k, match, pad, pad_character, pad_length, is_positive = true, sign = ''
         for (i = 0; i < tree_length; i++) {
-            node_type = get_type(parse_tree[i])
-            if (node_type === 'string') {
+            if (typeof parse_tree[i] === 'string') {
                 output[output.length] = parse_tree[i]
             }
-            else if (node_type === 'array') {
+            else if (parse_tree[i] instanceof Array) {
                 match = parse_tree[i] // convenience purposes only
                 if (match[2]) { // keyword argument
                     arg = argv[cursor]
@@ -54,12 +53,12 @@
                     arg = argv[cursor++]
                 }
 
-                if (re.not_type.test(match[8]) && re.not_primitive.test(match[8]) && get_type(arg) == 'function') {
+                if (re.not_type.test(match[8]) && re.not_primitive.test(match[8]) && arg instanceof Function) {
                     arg = arg()
                 }
 
-                if (re.numeric_arg.test(match[8]) && (get_type(arg) != 'number' && isNaN(arg))) {
-                    throw new TypeError(sprintf("[sprintf] expecting number but found %s", get_type(arg)))
+                if (re.numeric_arg.test(match[8]) && (typeof arg !== 'number' && isNaN(arg))) {
+                    throw new TypeError(sprintf("[sprintf] expecting number but found %T", arg))
                 }
 
                 if (re.number.test(match[8])) {
@@ -101,7 +100,7 @@
                         arg = (match[7] ? arg.substring(0, match[7]) : arg)
                     break
                     case 'T':
-                        arg = get_type(arg)
+                        arg = Object.prototype.toString.call(arg).slice(8, -1).toLowerCase()
                         arg = (match[7] ? arg.substring(0, match[7]) : arg)
                     break
                     case 'u':
@@ -193,21 +192,6 @@
         _argv = (argv || []).slice(0)
         _argv.splice(0, 0, fmt)
         return sprintf.apply(null, _argv)
-    }
-
-    /**
-     * helpers
-     */
-    function get_type(variable) {
-        if (typeof variable === 'number') {
-            return 'number'
-        }
-        else if (typeof variable === 'string') {
-            return 'string'
-        }
-        else {
-            return Object.prototype.toString.call(variable).slice(8, -1).toLowerCase()
-        }
     }
 
     /**

--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -189,8 +189,7 @@
     }
 
     var vsprintf = function(fmt, argv, _argv) {
-        _argv = (argv || []).slice(0)
-        _argv.splice(0, 0, fmt)
+        _argv = [fmt].concat(argv || [])
         return sprintf.apply(null, _argv)
     }
 


### PR DESCRIPTION
Each commit contains pretty distinct change and can be picked separately from the rest.
The only breaking change for older browsers is that `String.prototype.repeat` should be present.

These changes allow ~10% reduction of gzipped library size after Google Closure Compiler minifier. I've tried to replace uglifyjs with closure-compiler-js, but it seems to be broken (at least gulp version of it), awfully documented and I wan't able to get it working in advanced mode even though [Closure Compiler Service](https://closure-compiler.appspot.com) works perfectly with these sources.