### PR TITLE
refactor code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Update Travis config to test on all supported Node versions (i.e. 4+)
 * Reorganize README; add instructions re polyfills
+* Refactor the code
 
 ## 1.1.1 (2017-05-29)
 


### PR DESCRIPTION
Instead of direct use an array from call of `RegExp` `exec`,
fills a object with named properties that corresponding parse items.

Advantages:
 - the code more cleaner and easy to maintain
 - avoid memory pollution with unneeded results of `exec` (`input` and `lastIndex` properties) that stored in cache permanently.