### PR TITLE
Prevent arguments leak

### DIFF
--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -22,16 +22,19 @@
     }
 
     function sprintf(key) {
-        // `arguments` is not an array, but should be fine for this call
-        return sprintf_format(sprintf_parse(key), arguments)
+        var leakGuard = new Array(arguments.length-1);
+        for (var i=1; i<leakGuard.length; ++i) {
+            leakGuard[i] = arguments[i];
+        }
+        return sprintf_format(sprintf_parse(key), leakGuard);
     }
 
     function vsprintf(fmt, argv) {
-        return sprintf.apply(null, [fmt].concat(argv || []))
+        return sprintf_format(sprintf_parse(fmt), argv || []);
     }
 
     function sprintf_format(parse_tree, argv) {
-        var cursor = 1, tree_length = parse_tree.length, arg, output = '', i, k, ph, pad, pad_character, pad_length, is_positive, sign
+        var cursor = 0, tree_length = parse_tree.length, arg, output = '', i, k, ph, pad, pad_character, pad_length, is_positive, sign
         for (i = 0; i < tree_length; i++) {
             if (typeof parse_tree[i] === 'string') {
                 output += parse_tree[i]
@@ -48,7 +51,7 @@
                     }
                 }
                 else if (ph.param_no) { // positional argument (explicit)
-                    arg = argv[ph.param_no]
+                    arg = argv[ph.param_no-1]
                 }
                 else { // positional argument (implicit)
                     arg = argv[cursor++]

--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -23,10 +23,10 @@
 
     function sprintf(key) {
         var leakGuard = new Array(arguments.length-1);
-        for (var i=1; i<leakGuard.length; ++i) {
-            leakGuard[i] = arguments[i];
+        for (var i=0; i<leakGuard.length; ++i) {
+            leakGuard[i] = arguments[i+1];
         }
-        return sprintf_format(sprintf_parse(key), leakGuard);
+        return vsprintf(key, leakGuard);
     }
 
     function vsprintf(fmt, argv) {


### PR DESCRIPTION
In the original code, [the `arguments` object is leaked](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers), which disables optimization in the V8 engine. This pull request rectifies this by manually copying the passed-in arguments to a new array, keeping `arguments` intact.