### PR TITLE
Allow access to prototype properties

### DIFF
--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -41,8 +41,8 @@
                 if (ph.keys) { // keyword argument
                     arg = argv[cursor]
                     for (k = 0; k < ph.keys.length; k++) {
-                        if (arg[ph.keys[k]] === undefined) {
-                            throw new Error(sprintf('[sprintf] property "%s" does not exist', ph.keys[k]))
+                        if (arg == undefined) {
+                            throw new Error(sprintf('[sprintf] Cannot access property "%s" of undefined value "%s"', ph.keys[k], ph.keys[k-1]))
                         }
                         arg = arg[ph.keys[k]]
                     }

--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -41,7 +41,7 @@
                 if (ph.keys) { // keyword argument
                     arg = argv[cursor]
                     for (k = 0; k < ph.keys.length; k++) {
-                        if (!arg.hasOwnProperty(ph.keys[k])) {
+                        if (arg[ph.keys[k]] === undefined) {
                             throw new Error(sprintf('[sprintf] property "%s" does not exist', ph.keys[k]))
                         }
                         arg = arg[ph.keys[k]]

--- a/test/test_validation.js
+++ b/test/test_validation.js
@@ -57,15 +57,28 @@ describe('sprintfjs', function() {
             should_not_throw(fmt, [null])
         })
     })
-})
 
-describe('sprintfjs-prototype', function() {
+    it('should not throw Error for expression which evaluates to undefined', function() {
+        should_not_throw("%(x.y)s", {x : {}})
+    })
 
-    function Klass() {}
-    Klass.prototype = {
-        get x() { return 2 }
-    }
-    it('Prototype properties should not cause an error', function() {
-        should_not_throw('%(x)s', new Klass())
+    it('should throw own Error when expression evaluation would raise TypeError', function() {
+        var fmt = "%(x.y)s"
+        try {
+            sprintf(fmt, {})
+        } catch (e) {
+            assert(e.message.indexOf('[sprintf]') !== -1)
+        }
+    })
+
+    it('should not throw when accessing properties on the prototype', function() {
+        function C() { }
+        C.prototype = {
+            get x() { return 2 },
+            set y(v) { /*Noop */}
+        }
+        var c = new C()
+        should_not_throw("%(x)s", c)
+        should_not_throw("%(y)s", c)
     })
 })

--- a/test/test_validation.js
+++ b/test/test_validation.js
@@ -58,3 +58,14 @@ describe('sprintfjs', function() {
         })
     })
 })
+
+describe('sprintfjs-prototype', function() {
+
+    function Klass() {}
+    Klass.prototype = {
+        get x() { return 2 }
+    }
+    it('Prototype properties should not cause an error', function() {
+        should_not_throw('%(x)s', new Klass())
+    })
+})


### PR DESCRIPTION
Hi there, thanks for a great library! I've got a small PR, though it's entirely possible the current behaviour is by design (in which case I can work around it)

Basically, this works as expected
```javascript
sprintf("%(x)s", { x: 2 })
// "2"
```

While this doesn't (or at least, not how I'd expect ;) )
```javascript
class C { get x () { return 2 } }
sprintf("%(x)s", new C())
// Error: [sprintf] property "x" does not exist
```

The PR replaces `!hasOwnProperty` check with a `=== undefined` check and adds a test. It doesn't break any other tests but I guess it's possible someone's relying on an error here?
  