### PR TITLE
lint testing on PRs, update node.js versions in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: node_js
+
 node_js:
   - "node"
-  - "7"
+  - "10"
+  - "8"
   - "6"
-  - "5"
   - "4"
+
+script:
+    - npm run lint
+    - npm test

--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -14,11 +14,11 @@
         not_json: /[^j]/,
         text: /^[^\x25]+/,
         modulo: /^\x25{2}/,
-        placeholder: /^\x25(?:([1-9]\d*)\$|\(([^\)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-gijostTuvxX])/,
+        placeholder: /^\x25(?:([1-9]\d*)\$|\(([^)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-gijostTuvxX])/,
         key: /^([a-z_][a-z_\d]*)/i,
         key_access: /^\.([a-z_][a-z_\d]*)/i,
         index_access: /^\[(\d+)\]/,
-        sign: /^[\+\-]/
+        sign: /^[+-]/
     }
 
     function sprintf(key) {


### PR DESCRIPTION
- update node_js versions to released LTS versions
- remove three instances of unnecessary escaping (lint)
- enable lint testing as part of Travis CI tests

Questions:
- your feelings on dropping support for node.js 4?  (upstream has, I have, but it costs little to test, so there **might** be some value in leaving it on for testing. That way, you'll at least know when you've made a change that finally drives that nail in the coffin. OTOH, it'll prevent you from adopting some es6 features)
