### PR TITLE
fix #192 - remove String.repeat usage to remove IE11 polyfill requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ You can use `sprintf` and `vsprintf` (also aliased as `fmt` and `vfmt` respectiv
 
 `sprintf-js` should work in all modern browsers. As of v1.1.1, you might need polyfills for the following:
 
- - `String.prototype.repeat()` (any IE)
  - `Array.isArray()` (IE < 9)
  - `Object.create()` (IE < 9)
 

--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -131,7 +131,7 @@
                     }
                     pad_character = ph.pad_char ? ph.pad_char === '0' ? '0' : ph.pad_char.charAt(1) : ' '
                     pad_length = ph.width - (sign + arg).length
-                    pad = ph.width ? (pad_length > 0 ? pad_character.repeat(pad_length) : '') : ''
+                    pad = ph.width ? (pad_length > 0 ? new Array(pad_length + 1).join(pad_character) : '') : ''
                     output += ph.align ? sign + arg + pad : (pad_character === '0' ? sign + pad + arg : pad + sign + arg)
                 }
             }

--- a/test/test.js
+++ b/test/test.js
@@ -79,8 +79,8 @@ describe('sprintfjs', function() {
         assert.equal('3.14159', sprintf('%.6g', pi))
         assert.equal('3.14', sprintf('%.3g', pi))
         assert.equal('3', sprintf('%.1g', pi))
-        assert.equal('-000000123', sprintf('%+010d', -123))
-        assert.equal('______-123', sprintf("%+'_10d", -123))
+        assert.equal('-000000123', sprintf('%+010d', -123)) // negative padding
+        assert.equal('______-123', sprintf("%+'_10d", -123)) // negative padding
         assert.equal('-234.34 123.2', sprintf('%f %f', -234.34, 123.2))
 
         // padding


### PR DESCRIPTION
Fix https://github.com/alexei/sprintf.js/issues/192