### PR TITLE
Fix NaN being printed out as `-NaN`

### DIFF
--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -63,7 +63,7 @@
                 }
 
                 if (re.number.test(ph.type)) {
-                    is_positive = arg >= 0
+                    is_positive = arg >= 0 || isNaN(arg)
                 }
 
                 switch (ph.type) {

--- a/test/test.js
+++ b/test/test.js
@@ -41,6 +41,7 @@ describe('sprintfjs', function() {
         assert.equal('f', sprintf('%.1t', false))
         assert.equal('false', sprintf('%t', ''))
         assert.equal('false', sprintf('%t', 0))
+        assert.equal('NaN', sprintf('%f', NaN))
 
         assert.equal('undefined', sprintf('%T', undefined))
         assert.equal('null', sprintf('%T', null))


### PR DESCRIPTION
I've encountered incorrect behavior in cases involving `NaN`.
Consider the following example:
```
sprintf('%f', NaN) // '-NaN'
```

The library always adds `minus sign` before NaN. This fix considers `NaN` as a positive by including an additional check during sign detection.