### PR TITLE
Add GitHub actions for testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: Testing
+
+on:
+    push:
+        branches: '**'
+    pull_request:
+        branches: '**'
+
+jobs:
+    test:
+
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                node-version: [6.x, 8.x, 10.x]
+
+        steps:
+            - uses: actions/checkout@v3
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - run: npm ci | npm install
+            - run: npm test


### PR DESCRIPTION
Add testing with help of GitHub actions. 

- Testing in parallel on Node v6, v8 and v10.
- Job is trying to use `npm ci` if supported. 
- Also linting files as it is included in `npm test` command