### PR TITLE
Implemented support for `asterisk` replacement flag

### DIFF
--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -14,7 +14,7 @@
         not_json: /[^j]/,
         text: /^[^\x25]+/,
         modulo: /^\x25{2}/,
-        placeholder: /^\x25(?:([1-9]\d*)\$|\(([^)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-gijostTuvxX])/,
+        placeholder: /^\x25(?:([1-9]\d*)\$|\(([^)]+)\))?(\+)?(0|'[^$])?(-)?(\d+|\*)?(?:\.(\d+|\*))?([b-gijostTuvxX])/,
         key: /^([a-z_][a-z_\d]*)/i,
         key_access: /^\.([a-z_][a-z_\d]*)/i,
         index_access: /^\[(\d+)\]/,
@@ -49,6 +49,14 @@
                 }
                 else if (ph.param_no) { // positional argument (explicit)
                     arg = argv[ph.param_no]
+                }
+                else if (ph.width === '*') { // asterisk replacement (width)
+                    ph.width = parseInt(argv[cursor++], 10)
+                    arg = argv[cursor++]
+                }
+                else if (ph.precision === '*') { // asterisk replacement (precision)
+                    ph.precision = parseInt(argv[cursor++], 10)
+                    arg = argv[cursor++]
                 }
                 else { // positional argument (implicit)
                     arg = argv[cursor++]

--- a/test/test.js
+++ b/test/test.js
@@ -93,6 +93,8 @@ describe('sprintfjs', function() {
         assert.equal('>0000', sprintf('%0-5s', '>'))
         assert.equal('>____', sprintf("%'_-5s", '>'))
         assert.equal('xxxxxx', sprintf('%5s', 'xxxxxx'))
+        assert.equal('    <', sprintf('%*s', 5, '<'))
+        assert.equal('>    ', sprintf('%-*s',5, '>'))
         assert.equal('1234', sprintf('%02u', 1234))
         assert.equal(' -10.235', sprintf('%8.3f', -10.23456))
         assert.equal('-12.34 xxx', sprintf('%f %s', -12.34, 'xxx'))
@@ -101,6 +103,7 @@ describe('sprintfjs', function() {
 
         // precision
         assert.equal('2.3', sprintf('%.1f', 2.345))
+        assert.equal('3.1416', sprintf('%.*f', 4, pi))
         assert.equal('xxxxx', sprintf('%5.5s', 'xxxxxx'))
         assert.equal('    x', sprintf('%5.1s', 'xxxxxx'))
 


### PR DESCRIPTION
This PR closes #108 

Documentation: https://learn.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=msvc-170#width